### PR TITLE
Switch to hydra API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,3 @@ because Bioconductor packages are not listed, nor packages for which somehow {pa
 can't find a ranking.
 
 Contributions more than welcome!
-


### PR DESCRIPTION
   
    - Use hydra API instead of web
    - Use percentiles for both Bioc and CRAN (more comparable)
    - Link to logs
    - Don't track failing deps (see below)
    
    Easier to get the build evals, and build status is more informative.
    However, we can't get failing dep info from the API if needed, but then
    it gets complicated again. Packages with deps should rank higher in the
    percentiles.
